### PR TITLE
Revisions to crossover calling methods from quad structure

### DIFF
--- a/karyohmm/karyohmm.py
+++ b/karyohmm/karyohmm.py
@@ -380,6 +380,14 @@ class QuadHMM(AneuploidyHMM):
         )
         return path, states, deltas, psi
 
+    def viterbi_path(self, bafs, mat_haps, pat_haps, pi0=0.2, std_dev=0.1, r=1e-15):
+        """Obtain the restricted viterbi path for traceback."""
+        path, _, _, _ = self.viterbi_algorithm(
+            bafs, mat_haps, pat_haps, pi0=pi0, std_dev=std_dev, r=r
+        )
+        res_path = self.restrict_path(path)
+        return res_path
+
     def map_path(self, bafs, mat_haps, pat_haps, pi0=0.2, std_dev=0.1, r=1e-15):
         """Obtain the Maximum A-Posteriori Path across restricted states."""
         gammas, _, _ = self.forward_backward(

--- a/tests/test_quadhmm.py
+++ b/tests/test_quadhmm.py
@@ -80,18 +80,16 @@ def test_recomb_isolation_map(data):
 def test_recomb_isolation_viterbi(data):
     """Test the viterbi algorithm in the QuadHMM."""
     hmm = QuadHMM()
-    path01, _, _, _ = hmm.viterbi_algorithm(
+    res_path01 = hmm.viterbi_path(
         bafs=[data["baf_embryo0"], data["baf_embryo1"]],
         mat_haps=data["mat_haps_true"],
         pat_haps=data["pat_haps_true"],
     )
-    res_path01 = hmm.restrict_path(path01)
-    path02, _, _, _ = hmm.viterbi_algorithm(
+    res_path02 = hmm.viterbi_path(
         bafs=[data["baf_embryo0"], data["baf_embryo2"]],
         mat_haps=data["mat_haps_true"],
         pat_haps=data["pat_haps_true"],
     )
-    res_path02 = hmm.restrict_path(path02)
     mat_rec, pat_rec = hmm.isolate_recomb(res_path01, [res_path02])
     # True recombination events ...
     zs_maternal0 = data["zs_maternal0"]


### PR DESCRIPTION
A couple of key revisions to the estimation of crossovers from quad data. The key updates are: 

1. Parameter inference can now be accomplished using either `Nelder-Mead` or `L-BFGS-B` algorithms for optimization. The default is currently set to be the Nelder-Mead algorithm to prioritize accuracy over speed. 

2. We now support maximum-a-posteriori paths for the quadHMM that can be used instead of the viterbi paths (note that the paths in this case are already pre-restricted). We should actually just pre-restrict the viterbi path as well just so the primary outputs are the same here and the `restrict_path` function should not be called separately 

4. Delineation of crossover events from quad data can now use multiple sibling embryos to improve our detection of crossovers beyond just simple "triplets"  