### PR TITLE
Implementation of viterbi-based parental phase corrections

### DIFF
--- a/karyohmm/__init__.py
+++ b/karyohmm/__init__.py
@@ -16,7 +16,7 @@ Modules exported are:
 * PGTSimMosaic: module to generate synthetic PGT data for a mosaic biopsy
 """
 
-__version__ = "0.1.9b"
+__version__ = "0.2.0a"
 
 from .karyohmm import MetaHMM, MosaicEst, PhaseCorrect, QuadHMM
 from .simulator import PGTSim, PGTSimMosaic


### PR DESCRIPTION
This PR implements phase corrections for the parental genomes to 1) limit parental switch error rates 2) improve crossover estimation. 

The approach initially proceeds as follows: 

1. For each sibling calculate a Viterbi path trace in the 4-state HMM with the current parental haplotypes (assuming disomy)
2. For each path, count when the path copies from different parental haploypes identical by descent 
3. For inter-snp intervals where > $n_sib / 2$ siblings carry the switch, this is likely to be a switch error in that particular parent
4. Fix these switch errors by swapping the haplotypes for a given parent prior to this (keep track of the mismatches)
5. Repeat  from step 1

This is similar to the approach taken in [DuoHMM](https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1004234) for their phase correction in Duos - we just have taken the same idea for trios now and avoided directly relying on hard-called genotypes in the child. 

In preliminary tests it appears to reduce the number of mismatches and lowers the switch error rate as well. After PR acceptance we will validate that this method will reliably estimate crossover counts in realistic simulated data. 